### PR TITLE
Fix program freeze on duplicate song queue

### DIFF
--- a/utilities/scraper.py
+++ b/utilities/scraper.py
@@ -8,6 +8,10 @@ import ffmpeg
 import os
 # Currently only supports downloading the first video from a search query
 
+class SongAlreadyExists(Exception):
+    # Raised when trying to download a song that already exists
+    pass
+
 class SongInfo():
     #region properties
     @property
@@ -49,6 +53,9 @@ class YoutubeDownloader():
 
     def download(self, song):
         #TODO: Add support for direct URL's
+
+        if os.path.exists(song.mp3):
+            raise SongAlreadyExists
 
         YouTube(song.url).streams.first().download(output_path=song.output_path)
         ffmpeg.input(song.mp4).output(song.mp3).run()


### PR DESCRIPTION
Program was freezing up because console wanted confirmation on overwriting song.
Before download begins, if the song output file is already detected, raises on error
BUG: Not sure how to pass a specific Exception type up yet. Need to fix to make clearer
Removed non-functioning volume control code
Moved error handling to a specific error function.
fixes #57